### PR TITLE
Cleaning by relying on Coq 8.14

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *.glob
 *.vo
+*.vok
+*.vos
 .*.aux

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 *.vok
 *.vos
 .*.aux
+.lia.cache
+.nia.cache

--- a/Examples.v
+++ b/Examples.v
@@ -1,53 +1,56 @@
 Require Import PermutationSolver.
 
+Parameter A : Set.
+Axiom eq_dec : forall x y : A, {x = y} + {x <> y}.
+
 Goal
-  forall (a b c d e : list nat) (x y : nat),
+  forall (a b c d e : list A) (x y : A),
     Permutation (a ++ e) (x :: c) ->
     Permutation b (y :: d) ->
     Permutation (a ++ b ++ e) (x :: y :: c ++ d).
 Proof.
-  intros; permutation_solver.
+  intros; permutation_solver eq_dec.
 Qed.
 
 Notation "[ x ]" := (cons x nil).
 Notation "[ x ; y ; .. ; z ]" := (cons x (cons y .. (cons z nil) ..)).
 
 Goal
-  forall (a b : list nat) (x y : nat),
+  forall (a b : list A) (x y : A),
     Permutation a b ->
     Permutation [x] [y] ->
     Permutation (a ++ [x]) (y :: b).
 Proof.
-  intros; permutation_solver.
+  intros; permutation_solver eq_dec.
 Qed.
 
 Goal
-  forall (b u t e r f l y : nat) (xs ys : list nat),
+  forall (b u t e r f l y : A) (xs ys : list A),
     Permutation xs ys ->
     Permutation ([b;u;t;t;e;r]++[f;l;y]++xs) ([f;l;u;t;t;e;r]++ys++[b;y]).
 Proof.
-  intros; permutation_solver.
+  intros; permutation_solver eq_dec.
 Qed.
 
 (** Proving preorder, inorder and postorder of a BST are permutation of each
     other. *)
 Inductive tree : Set :=
 | Leaf : tree
-| Node : tree -> nat -> tree -> tree.
+| Node : tree -> A -> tree -> tree.
 
-Fixpoint inorder (t : tree) : list nat :=
+Fixpoint inorder (t : tree) : list A :=
   match t with
   | Leaf => nil
   | Node l v r => inorder l ++ v :: inorder r
   end.
 
-Fixpoint preorder (t : tree) : list nat :=
+Fixpoint preorder (t : tree) : list A :=
   match t with
   | Leaf => nil
   | Node l v r => v :: preorder l ++ preorder r
   end.
 
-Fixpoint postorder (t : tree) : list nat :=
+Fixpoint postorder (t : tree) : list A :=
   match t with
   | Leaf => nil
   | Node l v r => postorder l ++ postorder r ++ [v]
@@ -58,5 +61,5 @@ Theorem tree_orders :
     Permutation (inorder t) (preorder t) /\
     Permutation (inorder t) (postorder t).
 Proof.
-  induction t; simpl; intuition; permutation_solver.
+  induction t; simpl; intuition (permutation_solver eq_dec).
 Qed.

--- a/Makefile
+++ b/Makefile
@@ -3,4 +3,5 @@ all:
 	coqc Examples.v
 
 clean:
-	rm -f *.vo *.glob .*.aux
+	rm -f *.vo *.vok *.vos *.glob .*.aux
+

--- a/Makefile
+++ b/Makefile
@@ -3,5 +3,5 @@ all:
 	coqc Examples.v
 
 clean:
-	rm -f *.vo *.vok *.vos *.glob .*.aux
+	rm -f *.vo *.vok *.vos *.glob .*.aux .lia.cache .nia.cache
 

--- a/PermutationSolver.v
+++ b/PermutationSolver.v
@@ -5,7 +5,7 @@ Require Import Coq.Sets.Multiset.
 Require Export Coq.Sorting.Permutation.
 Require Import Coq.Sorting.PermutSetoid.
 Require Import Coq.Sorting.PermutEq.
-Require Import Omega.
+Require Import Lia.
 
 (** Refer to README.md for documentation. *)
 
@@ -50,4 +50,4 @@ Ltac permutation_solver Hdec :=
   repeat
     match goal with
     | [ |- context [if ?A then _ else _] ] => destruct A
-    end; omega.
+    end; lia.

--- a/PermutationSolver.v
+++ b/PermutationSolver.v
@@ -7,50 +7,46 @@ Require Import Coq.Sorting.PermutSetoid.
 Require Import Coq.Sorting.PermutEq.
 Require Import Omega.
 
-Opaque Nat.eq_dec.
-
 (** Refer to README.md for documentation. *)
 
-(** (foreverbell): generalize to all decidable instances. *)
-
-Lemma list_contents_app_multiplicity_plus :
-  forall (a : nat) (l m : list nat),
-    multiplicity (list_contents eq Nat.eq_dec (l ++ m)) a =
-    multiplicity (list_contents eq Nat.eq_dec l) a +
-    multiplicity (list_contents eq Nat.eq_dec m) a.
+Lemma list_contents_app_multiplicity_plus {A} Hdec :
+  forall (a : A) (l m : list A),
+    multiplicity (list_contents eq Hdec (l ++ m)) a =
+    multiplicity (list_contents eq Hdec l) a +
+    multiplicity (list_contents eq Hdec m) a.
 Proof.
-  intros; specialize (list_contents_app eq Nat.eq_dec l m).
+  intros; specialize (list_contents_app eq Hdec l m).
   intros. unfold meq, munion in H.
   specialize (H a); auto.
 Qed.
 
-Ltac permutation_simplify a (* variable for functional extensionality *) :=
+Ltac permutation_simplify Hdec a (* variable for functional extensionality *) :=
   repeat
     match goal with
     | [ H : Permutation _ _ |- _ ] =>
-        rewrite (permutation_Permutation Nat.eq_dec) in H;
+        rewrite (permutation_Permutation Hdec) in H;
         unfold permutation, meq in H;
         specialize (H a);
         repeat (
           simpl list_contents in H;
           unfold munion in H;
           simpl multiplicity in H;
-          try rewrite list_contents_app_multiplicity_plus in H
+          try rewrite (list_contents_app_multiplicity_plus Hdec) in H
         )
     | [ |- Permutation _ _ ] =>
-        rewrite (permutation_Permutation Nat.eq_dec);
+        rewrite (permutation_Permutation Hdec);
         unfold permutation, meq;
         intros a;
         repeat (
           simpl list_contents;
           unfold munion;
           simpl multiplicity;
-          try rewrite list_contents_app_multiplicity_plus
+          try rewrite (list_contents_app_multiplicity_plus Hdec)
         )
     end.
 
-Ltac permutation_solver :=
-  let a := fresh "a" in permutation_simplify a;
+Ltac permutation_solver Hdec :=
+  let a := fresh "a" in permutation_simplify Hdec a;
   repeat
     match goal with
     | [ |- context [if ?A then _ else _] ] => destruct A

--- a/PermutationSolver.v
+++ b/PermutationSolver.v
@@ -1,53 +1,18 @@
-Require Import Coq.Arith.PeanoNat.
-Require Import Coq.Classes.RelationClasses.
-Require Export Coq.Lists.List.
-Require Import Coq.Sets.Multiset.
-Require Export Coq.Sorting.Permutation.
-Require Import Coq.Sorting.PermutSetoid.
-Require Import Coq.Sorting.PermutEq.
-Require Import Lia.
+From Coq Require Export List Permutation.
+From Coq Require Import Lia.
 
 (** Refer to README.md for documentation. *)
 
-Lemma list_contents_app_multiplicity_plus {A} Hdec :
-  forall (a : A) (l m : list A),
-    multiplicity (list_contents eq Hdec (l ++ m)) a =
-    multiplicity (list_contents eq Hdec l) a +
-    multiplicity (list_contents eq Hdec m) a.
-Proof.
-  intros; specialize (list_contents_app eq Hdec l m).
-  intros. unfold meq, munion in H.
-  specialize (H a); auto.
-Qed.
-
-Ltac permutation_simplify Hdec a (* variable for functional extensionality *) :=
-  repeat
-    match goal with
-    | [ H : Permutation _ _ |- _ ] =>
-        rewrite (permutation_Permutation Hdec) in H;
-        unfold permutation, meq in H;
-        specialize (H a);
-        repeat (
-          simpl list_contents in H;
-          unfold munion in H;
-          simpl multiplicity in H;
-          try rewrite (list_contents_app_multiplicity_plus Hdec) in H
-        )
-    | [ |- Permutation _ _ ] =>
-        rewrite (permutation_Permutation Hdec);
-        unfold permutation, meq;
-        intros a;
-        repeat (
-          simpl list_contents;
-          unfold munion;
-          simpl multiplicity;
-          try rewrite (list_contents_app_multiplicity_plus Hdec)
-        )
-    end.
+#[local] Ltac permutation_simplify Hdec a (* variable for functional extensionality *) :=
+  repeat match goal with
+  | |- Permutation _ _ => rewrite (Permutation_count_occ Hdec); intros a;
+                          repeat (cbn; rewrite ? count_occ_app)
+  | H : Permutation _ _ |- _ => rewrite (Permutation_count_occ Hdec) in H; specialize (H a);
+                                repeat (cbn in H; rewrite ? count_occ_app in H)
+  end.
 
 Ltac permutation_solver Hdec :=
   let a := fresh "a" in permutation_simplify Hdec a;
-  repeat
-    match goal with
-    | [ |- context [if ?A then _ else _] ] => destruct A
-    end; lia.
+  repeat match goal with
+  | |- context[if ?A then _ else _] => destruct A
+  end; lia.

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ with addition should be trivial.
 Provide a tactics `permutation_solver` to attack permutations, which turns
 all Permutations in hypotheses and goals to multiplicity calculation.
 Using it is rather simple.
+It relies on a proof of decidability of equality for the type of the elements
+of the lists.
 
 ```coq
 Goal
@@ -46,6 +48,6 @@ Goal
     Permutation b (y :: d) ->
     Permutation (a ++ b ++ e) (x :: y :: c ++ d).
 Proof.
-  intros; permutation_solver.
+  intros; permutation_solver Nat.eq_dec.
 Qed.
 ```

--- a/README.md
+++ b/README.md
@@ -22,16 +22,13 @@ goal. This kind of proof method is boring and lengthy to develop.
 
 ## Idea
 
-Coq actually provides another way to define [permutation](https://coq.inria.fr/distrib/current/stdlib/Coq.Sorting.PermutSetoid.html#permutation).
 Here, the basic idea is, two lists are considered as permutation of each other,
 if and only if all elements have the same multiplicity in both lists. This
-property is proven as [a part of Coq's standard library](https://github.com/coq/coq/blob/307f08d2ad2aca5d48441394342af4615810d0c7/theories/Sorting/PermutEq.v#L123).
+property is proven as [a part of Coq's standard library](https://github.com/coq/coq/blob/19a8c5723625dbf49890f17858d330eb2f5ba94d/theories/Sorting/Permutation.v#L540).
 
 With this theorem, we transform the problem of proving permutation to simple
-multiplicity calculation, which is easy to be automated via Omega tactics in
-Coq. This should work, since list appending is transformed into multiplicity
-addition in this way, solving equations over the group of natural numbers
-with addition should be trivial.
+multiplicity calculation, which is easy to be automated via `lia` tactics in
+Coq.
 
 ## Implementation
 


### PR DESCRIPTION
Three contributions to make the development up to date:
* as suggested in the main file, extend to arbitrary types with decidable equality
* replace the deprecated tactic `omega` with `lia`
* rely on results about `count_occ` added in the standard library in `v8.14`